### PR TITLE
I fixed the backend database connection and the frontend OAuth path.

### DIFF
--- a/backend/backend_main.py
+++ b/backend/backend_main.py
@@ -165,7 +165,7 @@ async def list_users():
 
 @app.get("/api/oauth-config")
 def get_oauth_config():
-    path = os.path.join(os.path.dirname(__file__), '../auth/gcp-oauth.keys.json')
+    path = os.path.join(os.path.dirname(__file__), 'auth/gcp-oauth.keys.json')
     try:
         with open(path, 'r') as f:
             data = json.load(f)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - "8001:8001"
     environment:
-      - DATABASE_URL=postgresql://postgres:postgres@db:5432/mailwhisperer
+      - DATABASE_URL=postgresql://postgres:postgres@localhost:5432/mailwhisperer
       - GEMINI_API_KEY=${GEMINI_API_KEY}
       - MCP_SERVER_URL=${MCP_SERVER_URL}
     depends_on:

--- a/issues.md
+++ b/issues.md
@@ -1,0 +1,11 @@
+# Identified Issues and Status
+
+## 1. Backend: `socket.gaierror: [Errno -2] Name or service not known`
+
+*   **Description:** The backend service fails to start due to a `socket.gaierror` when trying to connect to the PostgreSQL database. This occurs because the `DATABASE_URL` in `docker-compose.yml` specifies `db` as the hostname, but due to `network_mode: host`, the service should connect via `localhost`.
+*   **Status:** Fixed. The `DATABASE_URL` in `docker-compose.yml` has been changed from `postgresql://postgres:postgres@db:5432/mailwhisperer` to `postgresql://postgres:postgres@localhost:5432/mailwhisperer`.
+
+## 2. Frontend: `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`
+
+*   **Description:** The frontend fails to parse the response from `/api/oauth-config` as JSON because it receives an HTML page instead. This is due to an incorrect file path construction in `backend/backend_main.py` for the `gcp-oauth.keys.json` file, leading to a 404 or server error that returns HTML.
+*   **Status:** Fixed. The path in `backend_main.py`'s `get_oauth_config` function has been corrected from `os.path.join(os.path.dirname(__file__), '../auth/gcp-oauth.keys.json')` to `os.path.join(os.path.dirname(__file__), 'auth/gcp-oauth.keys.json')`.


### PR DESCRIPTION
Here's what I did:

1.  **Backend:** I encountered an error: `socket.gaierror: [Errno -2] Name or service not known`.
    *   To resolve this, I changed the `DATABASE_URL` in `docker-compose.yml` for the `backend` service. It now uses `localhost` instead of `db` as the hostname. This adjustment was needed because both the `backend` and `db` services are configured with `network_mode: host`.

2.  **Frontend:** I addressed an error: `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`.
    *   I corrected the file path for `gcp-oauth.keys.json` within the `get_oauth_config` function in `backend/backend_main.py`. The path was mistakenly trying to access `../auth/` instead of the correct `auth/` relative to the `backend_main.py` file's location.

Additionally, I created a file named `issues.md` to document these problems and how I resolved them.