### PR TITLE
Fix: Correct MCP server domain for backend services

### DIFF
--- a/backend/tools_wrapper.py
+++ b/backend/tools_wrapper.py
@@ -6,7 +6,7 @@ import os
 import aiohttp
 from typing import Any, Dict, List, Optional
 
-MCP_BASE_URL = os.getenv("MCP_BASE_URL", "http://gmail:8000")
+MCP_BASE_URL = os.getenv("MCP_BASE_URL", "http://localhost:8000")
 
 async def list_emails() -> List[Dict[str, Any]]:
     """Hole alle E-Mails über die MCP-Bridge."""


### PR DESCRIPTION
The `MCP_BASE_URL` in `backend/tools_wrapper.py` was changed from 'http://gmail:8000' to 'http://localhost:8000'.

This change is necessary because all Docker services, including the backend and the 'gmail' MCP server, are configured with `network_mode: host`. In this network mode, `localhost` within any container correctly refers to the host machine, where the MCP server's port 8000 is exposed. Using 'gmail' as a hostname is unreliable in this setup as it would require DNS resolution that is not guaranteed within the host's network context for service names.

This addresses the issue where email toolcalls from the backend might fail due to an incorrect domain being used to reach the MCP server.

The `MCP_SERVER_URL` for agent WebSockets already defaults to a localhost-based URL, which is consistent with this change. Verification steps were included to ensure this environment variable is handled correctly during Docker execution.